### PR TITLE
Fixed TypedArray compatibility with Safari and IE 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@
                         throw new Error('invalid byte at index ' + i + '(' + arg[i] + ')');
                     }
                 }
-                return arg.slice(0);
+                return ArrayBuffer.isView(arg) ? arg.subarray(0) : arg.slice(0);
             }
         }
 


### PR DESCRIPTION
Hi!

We proudly used your library in our micro project https://github.com/skooda/passIon, but despite our best tries the aes-js didn't work in Safari. So here is the fix