### PR TITLE
Added bower.json file, registered

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,32 @@
+{
+  "name": "aes-js",
+  "description": "A pure JavaScript implementation of the AES block cipher and all common modes of operation.",
+  "main": "index.js",
+  "authors": [
+    "Richard Moore <me@ricmoo.com>"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "aes",
+    "aes-ctr",
+    "aes-ofb",
+    "aes-ecb",
+    "aes-cbc",
+    "aes-cfb",
+    "encrypt",
+    "decrypt",
+    "block",
+    "cipher"
+  ],
+  "homepage": "https://github.com/luckysw/aes-js",
+  "moduleType": [
+    "globals"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Hello,
I've tried to register the library on bower, to use it in the browser, and everything seems OK.
In this commit I only added the bower file, very simple (it doesn't even clean the output from the tests, etc...).
If this PR is accepted, we can change the bower public registry to point to your original repo instead this forked one.

Thank you,
 Luciano