### PR TITLE
removed global 'copy' array prototype extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,17 @@
 
     var createBuffer = null, convertBytesToString, convertStringToBytes = null;
 
+    // copy the array
+    var copyArray = function (sourceArray, targetArray, targetStart, sourceStart, sourceEnd) {
+        if (targetStart == null) { targetStart = 0; }
+        if (sourceStart == null) { sourceStart = 0; }
+        if (sourceEnd == null) { sourceEnd = sourceArray.length; }
+        for (var i = sourceStart; i < sourceEnd; i++) {
+            targetArray[targetStart++] = sourceArray[i];
+        }
+    }
+
+
     var slowCreateBuffer = function(arg) {
 
         // Passed in a single number, the length to pre-allocate
@@ -40,15 +51,6 @@
 
     if (typeof(Buffer) === 'undefined') {
         createBuffer = slowCreateBuffer;
-
-        Array.prototype.copy = function(targetArray, targetStart, sourceStart, sourceEnd) {
-            if (targetStart == null) { targetStart = 0; }
-            if (sourceStart == null) { sourceStart = 0; }
-            if (sourceEnd == null) { sourceEnd = this.length; }
-            for (var i = sourceStart; i < sourceEnd; i++) {
-                targetArray[targetStart++] = this[i];
-            }
-        }
 
         convertStringToBytes = function(text, encoding) {
 
@@ -419,7 +421,8 @@
             plaintext[i] ^= this._lastCipherblock[i];
         }
 
-        ciphertext.copy(this._lastCipherblock);
+        
+        copyArray(ciphertext, this._lastCipherblock);
 
         return plaintext;
     }
@@ -462,8 +465,8 @@
             }
 
             // Shift the register
-            this._shiftRegister.copy(this._shiftRegister, 0, this.segmentSize);
-            encrypted.copy(this._shiftRegister, 16 - this.segmentSize, i, i + this.segmentSize);
+            copyArray(this._shiftRegister, this._shiftRegister, 0, this.segmentSize);
+            copyArray(encrypted, this._shiftRegister, 16 - this.segmentSize, i, i + this.segmentSize);
         }
 
         return encrypted;
@@ -485,8 +488,8 @@
             }
 
             // Shift the register
-            this._shiftRegister.copy(this._shiftRegister, 0, this.segmentSize);
-            ciphertext.copy(this._shiftRegister, 16 - this.segmentSize, i, i + this.segmentSize);
+            copyArray(this._shiftRegister, this._shiftRegister, 0, this.segmentSize);
+            copyArray(ciphertext, this._shiftRegister, 16 - this.segmentSize, i, i + this.segmentSize);
         }
 
         return plaintext;


### PR DESCRIPTION
Hi Richard,
I have forked the library in order to avoid overwriting the copy prototype of the array, in order to be compatible with JS code that uses the for..in pattern to iterate arrays.

Let me know if you have concerns with that
Kind Regards
Davide
