### PR TITLE
Remove unused line to fix Babel incompatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 (function() {
     var root = this;
-    var previous_mymodule = root.mymodule;
 
     var createBuffer = null, convertBytesToString, convertStringToBytes = null;
 


### PR DESCRIPTION
Hi,

This module doesn't work when it's processed with Babel, because of this line:

var previous_mymodule = root.mymodule;

By default, Babel's module 'transform-es2015-modules-commonjs' makes global object undefined, so `root.mymodule` fails with runtime exception. Also, it seems, that previous_mymodule variable isn't used anywhere, so it could be safely removed.