### PR TITLE
Fix web browser example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ var aesjs = require('aes-js');
 To use `aes-js` in a web page, add the following:
 
 ```html
-<script type="text/javascript" src="https://raw.githubusercontent.com/ricmoo/aes-js/master/index.js"></script>
+<script type="text/javascript" src="https://rawgit.com/ricmoo/aes-js/master/index.js"></script>
 ```
 
 Keys


### PR DESCRIPTION
This PR fix the web browser example.

Using `https://raw.githubusercontent.com/` will raise: 

```
Refused to execute script from 'https://raw.githubusercontent.com/ricmoo/aes-js/master/index.js' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
```