### PR TITLE
handle counter initialization values larger than 32-bit int

### DIFF
--- a/index.js
+++ b/index.js
@@ -633,8 +633,9 @@
         }
 
         for (var index = 15; index >= 0; --index) {
-            this._counter[index] = value % 256;
-            value = value >> 8;
+            var byte = value & 0xff;
+            this._counter[index] = byte;
+            value = (value-byte) / 256;
         }
     }
 


### PR DESCRIPTION
There is currently a difference in the pyaes and the aes-js implementations.  The Python implementation will handle int Counter initialization values for long ints (greater than 32-bit).  The Javascript implementation however uses bit-shift operators, which cast the value to a 32-bit int.

For this counter:
c = new Counter(59981293859235);

Current c._counter is:
Uint8Array(16) [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 182, 177, 163]

With this modification, the higher bits are used, matching the pyaes library:
Uint8Array(16) [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 54, 141, 123, 182, 177, 163]
