### PR TITLE
Add the possibility to override _lastCipherblock for the CBC mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -475,11 +475,18 @@
         return ciphertext;
     }
 
-    ModeOfOperationCBC.prototype.decrypt = function(ciphertext) {
+    ModeOfOperationCBC.prototype.decrypt = function(ciphertext, customIV) {
         ciphertext = coerceArray(ciphertext);
 
         if ((ciphertext.length % 16) !== 0) {
             throw new Error('invalid ciphertext size (must be multiple of 16 bytes)');
+        }
+
+        if (typeof customIV !== 'undefined') {
+            if (customIV.length != 16) {
+                throw new Error('invalid initialation vector size (must be 16 bytes)');
+            }
+            this._lastCipherblock = coerceArray(customIV, true);
         }
 
         var plaintext = createArray(ciphertext.length);

--- a/index.js
+++ b/index.js
@@ -444,11 +444,18 @@
         this._aes = new AES(key);
     }
 
-    ModeOfOperationCBC.prototype.encrypt = function(plaintext) {
+    ModeOfOperationCBC.prototype.encrypt = function(plaintext, customIV) {
         plaintext = coerceArray(plaintext);
 
         if ((plaintext.length % 16) !== 0) {
             throw new Error('invalid plaintext size (must be multiple of 16 bytes)');
+        }
+
+        if (typeof customIV !== 'undefined') {
+            if (customIV.length != 16) {
+                throw new Error('invalid initialation vector size (must be 16 bytes)');
+            }
+            this._lastCipherblock = coerceArray(customIV, true);
         }
 
         var ciphertext = createArray(plaintext.length);


### PR DESCRIPTION
As discussed on the [issue 53](https://github.com/ricmoo/aes-js/issues/53), the re-use of _lastCipherblock is possibly unsafe.
This change simply allows user to re-specify their own IV (supposedly randomly generated) when encrypting/deciphering using CBC mode.