### PR TITLE
.npmignore add saving over 2MB for package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+node_modules/
+bower_components/
+test/
+generate-tests.py


### PR DESCRIPTION
Hello!

I've noticed your npm bundle [contains large unused files](https://zitros.github.io/npm-explorer/?p=aes-js) ([As for latest v3.1.1](https://zitros.github.io/npm-explorer/?p=aes-js@3.1.1)). This pull request adds appropriate files to `.npmignore` and will help to make `node_modules` cleaner.

Thanks!