### PR TITLE
Fix typo in AES Error Message

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@
 
     var AES = function(key) {
         if (!(this instanceof AES)) {
-            throw Error('AES must be instanitated with `new`');
+            throw Error('AES must be instantiated with `new`');
         }
 
         Object.defineProperty(this, 'key', {


### PR DESCRIPTION
While writing the documentation about the deezer HTML5 player, I found a cute typo that led me to this PR.